### PR TITLE
Update copyright year and homepage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # Capitaine cursors, macOS inspired cursors based on KDE Breeze
 # Copyright (c) 2016 Keefer Rourke <mail@krourke.org> and others.
-# Copyright (c) 2021 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> and others.
+# Copyright (c) 2021-2022 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> and others.
 
 function set_sizes()
 {

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: mamolinux-cursors
 Section: gnome
 Priority: optional
-Homepage: https://github.com/hsbasu/freedomos-cursors
+Homepage: https://github.com/hsbasu/mamolinux-cursors
 Maintainer: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
 Build-Depends: debhelper (>= 12), bc, inkscape, gtk2-engines-pixbuf, gtk2-engines-murrine, gnome-themes-standard, x11-apps
 Standards-Version: 4.5.0

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
 Source: https://github.com/hsbasu/mamolinux-cursors
 
 Files: *
-Copyright: 2021 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> and Contributors
+Copyright: 2021-2022 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> and Contributors
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -23,5 +23,5 @@ License: GPL-3+
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
 
 Files: usr/share/icons/*
-Copyright: 2021 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> and Contributors
+Copyright: 2021-2022 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> and Contributors
 License: CC-BY-SA-4


### PR DESCRIPTION
- Update copyright year to 2022
- Update homepage to github.com/hsbasu/mamolinux-cursors