### PR TITLE
Fix lintian warnings in debian

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -2,14 +2,23 @@
 set -e
 
 case "$1" in
-    configure|abort-upgrade|abort-remove|abort-deconfigure)
-    if which update-icon-caches >/dev/null 2>&1
-    then
-        update-icon-caches -f /usr/share/icons/Sucharu*
-    fi
+    configure)
+        if which update-icon-caches >/dev/null 2>&1
+        then
+            update-icon-caches -f /usr/share/icons/Sucharu*
+        fi
     ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
     *)
         echo "postinst called with unknown argument \`$1'" >&2
         exit 1
     ;;
 esac
+
+
+#DEBHELPER#
+
+exit 0

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,9 +1,24 @@
 #!/bin/sh
 set -e
+
 # Automatically added by dh_icons
-if which update-icon-caches >/dev/null 2>&1 ; then
-  for DIR in `ls -d /usr/share/icons/*`; do
-    update-icon-caches /usr/share/icons/$DIR -f
-  done
-fi
+case "$1" in
+    purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        if which update-icon-caches >/dev/null 2>&1 ; then
+            for DIR in `ls -d /usr/share/icons/*`; do
+                update-icon-caches /usr/share/icons/$DIR -f
+            done
+        fi
+    ;;
+
+    *)
+        echo "postrm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
 # End automatically added section
+
+
+#DEBHELPER#
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh ${@}
+	dh $@  
 
 override_dh_builddeb:
 	dh_builddeb -- -Zxz -z9
-	


### PR DESCRIPTION
- debian/postinst: fix maintainer-script-lacks-debhelper-token
- debian/postrm: fix maintainer-script-lacks-debhelper-token
- debian/rules: fix no-newline-at-end